### PR TITLE
Validate that flen > 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 ### Fixed
 
+- Fixed crash when using `-B` on a file of 0 bytes.
+  ([#21](https://github.com/asomers/fsx-rs/pull/21))
+
 - Fixed crashes when using `-B` on files larger than 256 kB.
   ([#17](https://github.com/asomers/fsx-rs/pull/17))
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -977,6 +977,10 @@ impl From<Cli> for Exerciser {
         } else {
             cli.flen.into()
         };
+        if flen == 0 {
+            error!("ERROR: file length must be greater than zero");
+            process::exit(2);
+        }
         let file_size = if cli.blockmode { flen } else { 0 };
         let mut original_buf = vec![0u8; flen as usize];
         let good_buf = vec![0u8; flen as usize];

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -351,3 +351,29 @@ fn artifacts_dir() {
     // finally, clean it up.
     fs::remove_file(&fsxgoodfname).unwrap();
 }
+
+// https://github.com/asomers/fsx-rs/issues/20
+#[test]
+fn blockmode_zero() {
+    let tf = NamedTempFile::new().unwrap();
+    let artifacts_dir = TempDir::new().unwrap();
+
+    let cmd = Command::cargo_bin("fsx")
+        .unwrap()
+        .env("RUST_LOG", "warn")
+        .args(["-B", "-N2", "-S72", "-P"])
+        .arg(artifacts_dir.path())
+        .arg(tf.path())
+        .assert()
+        .failure();
+
+    let actual_stderr = CString::new(cmd.get_output().stderr.clone())
+        .unwrap()
+        .into_string()
+        .unwrap();
+    assert_eq!(
+        actual_stderr,
+        "[ERROR fsx] ERROR: file length must be greater than zero
+"
+    );
+}


### PR DESCRIPTION
This is mostly useful with blockmode, where flen is inferred from the existing file's size.

Fixes #20