### PR TITLE
Fix the build on NetBSD etc

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,6 +17,17 @@ build: &BUILD
     - . $HOME/.cargo/env || true
     - cargo test
 
+# Check only, for cross-OS testing
+check: &CHECK
+  cargo_cache:
+    folder: $HOME/.cargo/registry
+    fingerprint_script: cat Cargo.lock || echo ""
+  setup_script:
+    - rustup target add $TARGET
+  check_script:
+    - . $HOME/.cargo/env || true
+    - cargo check --target $TARGET --all-features
+
 task:
   env:
     VERSION: 1.63.0
@@ -61,4 +72,13 @@ task:
   setup_script:
     - rustup component add rustfmt
   << : *BUILD
+  before_cache_script: rm -rf $HOME/.cargo/registry/index
+
+task:
+  name: NetBSD MSRV
+  env:
+    TARGET: x86_64-unknown-netbsd
+  container:
+    image: rust:1.63.0
+  << : *CHECK
   before_cache_script: rm -rf $HOME/.cargo/registry/index

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ name = "fsx"
 version = "0.1.1"
 dependencies = [
  "assert_cmd",
+ "cfg-if",
  "clap",
  "env_logger",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = "1.63"
 keywords = ["filesystem", "test"]
 
 [dependencies]
+cfg-if = "1.0"
 clap = { version = "4.0.12", features = ["derive"] }
 env_logger = "0.10.0"
 libc = "0.2.139"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -524,6 +524,17 @@ fn weights(#[case] wconf: &str, #[case] stderr: &str) {
 }
 
 #[test]
+#[cfg_attr(
+    not(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "emscripten",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux"
+    )),
+    ignore
+)]
 fn posix_fallocate() {
     let mut cf = NamedTempFile::new().unwrap();
     cf.write_all(b"[weights]\nposix_fallocate=1000000").unwrap();


### PR DESCRIPTION
Some OSes do not support posix_fallocate.  For them, fix the build, but abort if the user ever tries to invoke posix_fallocate.

Add CI testing (build only) for NetBSD.  For others, such as Darwin, it's too hard for me to test them locally.