### PR TITLE
Add hole-punching

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,27 @@
+#[cfg(target_os = "freebsd")]
+fn main() {
+    use std::{env, process::Command};
+
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
+
+    // When self-compiling, enable fspacectl if the build host is FreeBSD 14+
+    // This is easier than using bindgen, which pulls in tons of dependencies.
+    if env::var("CARGO_CFG_TARGET_OS").unwrap() == "freebsd" {
+        let output = Command::new("freebsd-version")
+            .arg("-u")
+            .output()
+            .expect("Failed to execute freebsd-version");
+        let v = String::from_utf8_lossy(&output.stdout);
+        if let Some((major, _)) = v.split_once('.') {
+            if let Ok(major) = major.parse::<i32>() {
+                if major >= 14 {
+                    println!("cargo:rustc-cfg=have_fspacectl");
+                }
+            }
+        }
+    }
+}
+
+// When cross-compiling, never enable fspacectl
+#[cfg(not(target_os = "freebsd"))]
+fn main() {}

--- a/doc/fsx.toml
+++ b/doc/fsx.toml
@@ -87,3 +87,10 @@ fdatasync = 1
 # NB: not all file systems are capable of supporting this operation.
 # Default: 0
 posix_fallocate = 0
+
+# Hole punching
+# FreeBSD: fspacectl()
+# Linux: fallocate(_, FALLOC_FL_PUNCH_HOLE, _, _)
+# Others: not supported
+# Default: 0
+punch_hole = 0

--- a/src/main.rs
+++ b/src/main.rs
@@ -1183,6 +1183,17 @@ impl Exerciser {
 
     fn punch_hole(&mut self, offset: u64, len: u64) {
         assert!(offset + len <= self.file_size);
+
+        if len == 0 {
+            self.oplog.push(LogEntry::Skip(Op::PunchHole));
+            debug!(
+                "{:width$} skipping zero size hole punch",
+                self.steps,
+                width = self.stepwidth
+            );
+            return;
+        }
+
         safemem::write_bytes(
             &mut self.good_buf[offset as usize..(offset + len) as usize],
             0,


### PR DESCRIPTION
On FreeBSD 14+ this uses fspacectl().
On Linux-like OSes, it uses fallocate with FALLOC_FL_PUNCH_HOLE. On Illumos it could use fcntl with F_FREESP, but that isn't implemented yet.
Other operating systems do not support this operation.

Fixes #3