### PR TITLE
remove suppression for clippy::items_after_test_module

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,9 +1,5 @@
 // vim: tw=80
 
-// This lint doesn't play nicely with rstest and modules.
-// https://github.com/rust-lang/rust-clippy/issues/11050
-#![allow(clippy::items_after_test_module)]
-
 use std::{ffi::CString, fs, io::Write, process::Command};
 
 use assert_cmd::prelude::*;


### PR DESCRIPTION
Because it's fixed in the lasted Clippy.

https://github.com/rust-lang/rust-clippy/issues/11050