### PR TITLE
Update FreeBSD CI images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,19 +31,19 @@ check: &CHECK
 task:
   env:
     VERSION: 1.63.0
-  name: FreeBSD 12.4 MSRV
+  name: FreeBSD 13.2 MSRV
   freebsd_instance:
-    image: freebsd-12-4-release-amd64
+    image: freebsd-13-2-release-amd64
   << : *FREEBSD_SETUP
   << : *BUILD
   before_cache_script: rm -rf $HOME/.cargo/registry/index
 
 task:
-  name: FreeBSD 13.2 nightly
+  name: FreeBSD 14.0 nightly
   env:
     VERSION: nightly
   freebsd_instance:
-    image: freebsd-13-2-release-amd64
+    image: freebsd-14-0-release-amd64-ufs
   << : *FREEBSD_SETUP
   << : *BUILD
   clippy_script:


### PR DESCRIPTION
Drop nearly-EoL 12.4.  Move 13.2 nightly to 14.0 nightly.