### PR TITLE
Eliminate dependency on the unmaintained safemem crate.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,6 +36,10 @@ task:
     image: freebsd-13-2-release-amd64
   << : *FREEBSD_SETUP
   << : *BUILD
+  audit_script:
+    - . $HOME/.cargo/env
+    - pkg install -y cargo-audit
+    - cargo audit
   before_cache_script: rm -rf $HOME/.cargo/registry/index
 
 task:
@@ -54,10 +58,6 @@ task:
     - . $HOME/.cargo/env
     - rustup component add rustfmt
     - cargo fmt -- --check --color=never
-  audit_script:
-    - . $HOME/.cargo/env
-    - pkg install -y cargo-audit
-    - cargo audit
   # Test our minimal version spec
   minver_test_script:
     - . $HOME/.cargo/env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,6 @@ dependencies = [
  "rand_xorshift",
  "ringbuffer",
  "rstest",
- "safemem",
  "serde",
  "serde_derive",
  "tempfile",
@@ -639,12 +638,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ nix = { version = "0.27.1", default-features = false, features = [ "feature", "f
 rand = { version = "0.8.5" }
 rand_xorshift = "0.3"
 ringbuffer = "0.11.0"
-safemem = "0.3.0"
 serde = "1.0"
 serde_derive = "1.0"
 toml = "0.5.0"


### PR DESCRIPTION
It actually hasn't been necessary since 1.50.0, when the standard library gained Slice::fill.

https://rustsec.org/advisories/RUSTSEC-2023-0081