### PR TITLE
Test with -Zdirect-minimal-versions instead of -Zminimal-versions in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,7 +62,7 @@ task:
   # Test our minimal version spec
   minver_test_script:
     - . $HOME/.cargo/env
-    - cargo update -Zminimal-versions
+    - cargo update -Zdirect-minimal-versions
     - cargo check --all-targets
   before_cache_script: rm -rf $HOME/.cargo/registry/index
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ cfg-if = "1.0"
 clap = { version = "4.0.12", features = ["derive"] }
 clap-verbosity-flag = "2.1.1"
 env_logger = "0.11.1"
-libc = "0.2.139"
+libc = "0.2.154"
 log = "0.4.17"
 mdconfig = "0.2.0"
 nix = { version = "0.28.0", default-features = false, features = [ "feature", "fs", "ioctl", "mman", "zerocopy" ]}
 rand = { version = "0.8.5" }
 rand_xorshift = "0.3"
 ringbuffer = "0.11.0"
-serde = "1.0.119"
-serde_derive = "1.0.119"
+serde = "1.0.145"
+serde_derive = "1.0.145"
 toml = { version = "0.8.11", default-features = false, features = [ "parse" ] }
 
 [dev-dependencies]


### PR DESCRIPTION
The difference is subtle, but direct-minimal-versions is better since our dependencies can't publish an update that suddenly breaks our CI.