### PR TITLE
Fix the tests with nightly cargo's new -Zbuild-dir feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,12 +61,14 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.7"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3d466004a8b4cb1bc34044240a2fd29d17607e2e3bd613eb44fd48e8100da3"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
 dependencies = [
+ "anstyle",
  "bstr",
  "doc-comment",
+ "libc",
  "predicates",
  "predicates-core",
  "predicates-tree",
@@ -204,12 +206,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "either"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "env_filter"
@@ -432,15 +428,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "konst_kernel"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,20 +521,20 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "2.1.5"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
+ "anstyle",
  "difflib",
- "itertools",
  "predicates-core",
 ]
 
 [[package]]
 name = "predicates-core"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0.145"
 toml = { version = "0.8.11", default-features = false, features = [ "parse" ] }
 
 [dev-dependencies]
-assert_cmd = "2.0"
+assert_cmd = "2.0.17"
 pretty_assertions = "1.3"
 rstest = "0.16.0"
 tempfile = "3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,8 @@ cfg_if! {
 /// Calculate the maximum field width needed to print numbers up to this size
 fn field_width(max: usize, hex: bool) -> usize {
     if hex {
-        2 + (8 * mem::size_of_val(&max) - max.leading_zeros() as usize + 3) / 4
+        2 + (8 * mem::size_of_val(&max) - max.leading_zeros() as usize)
+            .div_ceil(4)
     } else {
         1 + (max as f64).log(10.0) as usize
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,7 +2,7 @@
 
 use std::{ffi::CString, fs, io::Write, process::Command};
 
-use assert_cmd::prelude::*;
+use assert_cmd::{cargo::cargo_bin, prelude::*};
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 use tempfile::{NamedTempFile, TempDir};
@@ -288,8 +288,7 @@ fn stability(#[case] conf: &str, #[case] args: &str, #[case] stderr: &str) {
         tf.as_file_mut().set_len(1048576).unwrap();
     }
 
-    let cmd = Command::cargo_bin("fsx")
-        .unwrap()
+    let cmd = Command::new(cargo_bin!("fsx"))
         .args(args.split_ascii_whitespace())
         .args(["-vv", "-f"])
         .arg(cf.path())
@@ -308,8 +307,7 @@ fn stability(#[case] conf: &str, #[case] args: &str, #[case] stderr: &str) {
 fn miscompare() {
     let tf = NamedTempFile::new().unwrap();
 
-    let cmd = Command::cargo_bin("fsx")
-        .unwrap()
+    let cmd = Command::new(cargo_bin!("fsx"))
         .args(["-vv", "-N10", "-S10", "--inject", "3"])
         .arg(tf.path())
         .assert()
@@ -357,8 +355,7 @@ fn artifacts_dir() {
     let tf = NamedTempFile::new().unwrap();
     let artifacts_dir = TempDir::new().unwrap();
 
-    Command::cargo_bin("fsx")
-        .unwrap()
+    Command::new(cargo_bin!("fsx"))
         .args(["-vv", "-N2", "-S11", "--inject", "1", "-P"])
         .arg(artifacts_dir.path())
         .arg(tf.path())
@@ -392,8 +389,7 @@ truncate = 0",
     let tf = NamedTempFile::new().unwrap();
     let artifacts_dir = TempDir::new().unwrap();
 
-    let cmd = Command::cargo_bin("fsx")
-        .unwrap()
+    let cmd = Command::new(cargo_bin!("fsx"))
         .args(["-N2", "-S72", "-P"])
         .arg(artifacts_dir.path())
         .arg(tf.path())
@@ -429,8 +425,7 @@ truncate = 0",
     tf.as_file_mut().set_len(1 << 40).unwrap(); // 1 TiB
     let artifacts_dir = TempDir::new().unwrap();
 
-    Command::cargo_bin("fsx")
-        .unwrap()
+    Command::new(cargo_bin!("fsx"))
         .args(["-N1", "-S72", "-P"])
         .arg(artifacts_dir.path())
         .arg(tf.path())
@@ -513,8 +508,7 @@ fn read_weights(#[case] wconf: &str, #[case] stderr: &str) {
     let mut tf = NamedTempFile::new().unwrap();
     tf.as_file_mut().set_len(8192).unwrap();
 
-    let cmd = Command::cargo_bin("fsx")
-        .unwrap()
+    let cmd = Command::new(cargo_bin!("fsx"))
         .args(["-vv", "-S", "200", "-N", "1", "-P", "/tmp"])
         .arg("-f")
         .arg(cf.path())
@@ -572,8 +566,7 @@ fn weights(#[case] wconf: &str, #[case] stderr: &str) {
 
     let tf = NamedTempFile::new().unwrap();
 
-    let cmd = Command::cargo_bin("fsx")
-        .unwrap()
+    let cmd = Command::new(cargo_bin!("fsx"))
         .args(["-vv", "-S", "200", "-N", "1"])
         .arg("-f")
         .arg(cf.path())
@@ -605,7 +598,7 @@ fn posix_fallocate() {
 
     let tf = NamedTempFile::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("fsx").unwrap();
+    let mut cmd = Command::new(cargo_bin!("fsx"));
     cmd.args(["-vv", "-S", "200", "-N", "1"])
         .arg("-f")
         .arg(cf.path())
@@ -655,7 +648,7 @@ fn posix_fadvise() {
 
     let tf = NamedTempFile::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("fsx").unwrap();
+    let mut cmd = Command::new(cargo_bin!("fsx"));
     cmd.args(["-vv", "-N", "6", "-S", "12318153001044186923"])
         .arg("-f")
         .arg(cf.path())
@@ -693,8 +686,7 @@ fn punch_hole() {
 
     let tf = NamedTempFile::new().unwrap();
 
-    let cmd = Command::cargo_bin("fsx")
-        .unwrap()
+    let cmd = Command::new(cargo_bin!("fsx"))
         .args(["-vv", "-S", "301", "-N", "10", "-P", "/tmp", "-f"])
         .arg(cf.path())
         .arg(tf.path())
@@ -740,8 +732,7 @@ fn punch_hole_monitor() {
 
     let tf = NamedTempFile::new().unwrap();
 
-    let cmd = Command::cargo_bin("fsx")
-        .unwrap()
+    let cmd = Command::new(cargo_bin!("fsx"))
         .args([
             "-vv",
             "-S",
@@ -789,8 +780,7 @@ fn punch_hole_zero() {
 
     let tf = NamedTempFile::new().unwrap();
 
-    let cmd = Command::cargo_bin("fsx")
-        .unwrap()
+    let cmd = Command::new(cargo_bin!("fsx"))
         .args(["-vv", "-S", "301", "-N", "1", "-f"])
         .arg(cf.path())
         .arg(tf.path())
@@ -934,8 +924,7 @@ truncate = 0",
 
         let artifacts_dir = TempDir::new().unwrap();
 
-        Command::cargo_bin("fsx")
-            .unwrap()
+        Command::new(cargo_bin!("fsx"))
             .args(["-N10", "-P"])
             .arg(artifacts_dir.path())
             .arg("-f")


### PR DESCRIPTION
Need to update assert_cmd to find the correct path to the binary.