### PR TITLE
Fix posix_fallocate with recent versions of OpenZFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Fixed
+
+- Fixed `posix_fallocate` with recent versions of OpenZFS.
+  ([#62](https://github.com/asomers/fsx-rs/pull/62))
+
 ## [0.3.0] - 2025-05-19
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -1620,7 +1620,9 @@ impl Exerciser {
             posix_fallocate(self.file.as_raw_fd(), offset as i64, len as i64);
         match r {
             Ok(()) => (),
-            Err(nix::Error::EINVAL) => {
+            Err(nix::Error::EINVAL | nix::Error::EOPNOTSUPP) => {
+                // POSIX specifies either EINVAL or EOPNOTSUPPT to indicate that
+                // the file system does not support posix_fallocate.
                 eprintln!("Test file system does not support posix_fallocate.");
                 self.fail();
             }


### PR DESCRIPTION
POSIX long specified EINVAL to indicate that a file system does not support posix_fallocate.  But POSIX 1003.1-2024 Issue 8 changes that error code to EOPNOTSUPP.  OpenZFS has already switched to the new convention.  Modify fsx to recognize either error.

https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_fallocate.html